### PR TITLE
feat(User): Add functionality for authenticating a Spotify User

### DIFF
--- a/Spotify-Data-Collector/Classes/ISpotify.cs
+++ b/Spotify-Data-Collector/Classes/ISpotify.cs
@@ -16,6 +16,18 @@ namespace SpotifyDataCollector
         Task InitializeClientAsync();
 
         /// <summary>
+        /// Get the client ID.
+        /// </summary>
+        /// <returns></returns>
+        string GetClientId();
+
+        /// <summary>
+        /// Get the client secret.
+        /// </summary>
+        /// <returns></returns>
+        string GetClientSecret();
+
+        /// <summary>
         /// Get artist details
         /// </summary>
         /// <param name="artistId">Spotify ID for the artist (Note:  This ID differs based on Country Code)</param>

--- a/Spotify-Data-Collector/Classes/ISpotifyUser.cs
+++ b/Spotify-Data-Collector/Classes/ISpotifyUser.cs
@@ -1,0 +1,27 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using SpotifyAPI.Web;
+namespace SpotifyUser{
+    public interface IUser
+    {
+        /// <summary>
+        /// Get the login URI
+        /// </summary>
+        /// <returns></returns>
+        string LoginURI { get; }
+
+        /// <summary>
+        /// Initiate the Spotify login process
+        /// </summary>
+        /// <param name="context"></param>
+        /// <returns></returns>
+        Task InitiateSpotifyLoginAsync(HttpContext context);
+
+        /// <summary>
+        /// Get the Spotify client
+        /// </summary>
+        /// <param name="context"></param>
+        /// <returns></returns>
+        Task<SpotifyClient> GetSpotifyClientAsync(HttpContext context);
+    }
+}

--- a/Spotify-Data-Collector/Classes/ISpotifyUser.cs
+++ b/Spotify-Data-Collector/Classes/ISpotifyUser.cs
@@ -14,19 +14,26 @@ namespace SpotifyUser{
         string SpotifyUserID { get; set;}
 
         SpotifyClient SpotifyClient { get; set; }
+
+        string SpotifyToken { get; set; }
+
+        string TokenExpireTime { get; set; }
+
+        string SpotifyAccessCode { get; set; }
         /// <summary>
         /// Initiate the Spotify login process
         /// </summary>
         /// <param name="context"></param>
         /// <returns></returns>
         Task InitiateSpotifyLoginAsync(HttpContext context);
+        Task RefreshTokenAsync();
         bool IsTokenExpired();
         /// <summary>
         /// Get the Spotify client
         /// </summary>
         /// <param name="context"></param>
         /// <returns></returns>
-        Task<SpotifyClient> GetSpotifyClientAsync(HttpContext context);
+        Task<SpotifyClient> GetSpotifyClientAsync(string code);
 
         Task<List<TrackDTO>> GetRecentTracksAsync(SpotifyClient spotify, DateTimeOffset? startTime = null, DateTimeOffset? endTime = null);
     }

--- a/Spotify-Data-Collector/Classes/ISpotifyUser.cs
+++ b/Spotify-Data-Collector/Classes/ISpotifyUser.cs
@@ -12,13 +12,15 @@ namespace SpotifyUser{
         string LoginURI { get; }
 
         string SpotifyUserID { get; set;}
+
+        SpotifyClient SpotifyClient { get; set; }
         /// <summary>
         /// Initiate the Spotify login process
         /// </summary>
         /// <param name="context"></param>
         /// <returns></returns>
         Task InitiateSpotifyLoginAsync(HttpContext context);
-
+        bool IsTokenExpired();
         /// <summary>
         /// Get the Spotify client
         /// </summary>

--- a/Spotify-Data-Collector/Classes/ISpotifyUser.cs
+++ b/Spotify-Data-Collector/Classes/ISpotifyUser.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Spotify_Data_Collector;
 using SpotifyAPI.Web;
 namespace SpotifyUser{
     public interface IUser
@@ -10,6 +11,7 @@ namespace SpotifyUser{
         /// <returns></returns>
         string LoginURI { get; }
 
+        string SpotifyUserID { get; set;}
         /// <summary>
         /// Initiate the Spotify login process
         /// </summary>
@@ -23,5 +25,7 @@ namespace SpotifyUser{
         /// <param name="context"></param>
         /// <returns></returns>
         Task<SpotifyClient> GetSpotifyClientAsync(HttpContext context);
+
+        Task<List<TrackDTO>> GetRecentTracksAsync(SpotifyClient spotify, DateTimeOffset? startTime = null, DateTimeOffset? endTime = null);
     }
 }

--- a/Spotify-Data-Collector/Classes/Spotify.cs
+++ b/Spotify-Data-Collector/Classes/Spotify.cs
@@ -24,6 +24,22 @@ namespace SpotifyDataCollector
         private SpotifyClient spotifyClient;
 
         /// <summary>
+        /// Get the client ID.
+        /// </summary>
+        /// <returns></returns>
+        public string GetClientId()
+        {
+            return clientId;
+        }
+        /// <summary>
+        /// Get the client secret.
+        /// </summary>
+        /// <returns></returns>
+        public string GetClientSecret()
+        {
+            return clientSecret;
+        }
+        /// <summary>
         /// Initializes the Spotify client with the client ID and client secret.
         /// </summary>
         /// <returns>Returns the Spotify client.</returns>

--- a/Spotify-Data-Collector/Classes/Spotify.cs
+++ b/Spotify-Data-Collector/Classes/Spotify.cs
@@ -73,7 +73,7 @@ namespace SpotifyDataCollector
         public async Task<TrackDTO> GetTrack(string trackId)
         {
             var track = await spotifyClient.Tracks.Get(trackId);
-            return new TrackDTO(track.Name, track.Id, track.DurationMs.ToString(), track.Popularity.ToString(), track.ExternalUrls["spotify"], track.Album.Id, track.Album.ReleaseDate, track.DiscNumber.ToString(), track.TrackNumber.ToString());
+            return new TrackDTO(track.Name, track.Id, track.DurationMs.ToString(), track.Popularity.ToString(), track.ExternalUrls["spotify"], track.Album.Id, track.Album.ReleaseDate, track.DiscNumber.ToString(), track.TrackNumber.ToString(), track.Artists[0].Id, track.Artists[0].Name);
         }
 
         /// <summary>
@@ -224,7 +224,9 @@ namespace SpotifyDataCollector
                         trackDetails.AlbumId,
                         trackDetails.ReleaseDate,
                         trackDetails.Disc_Number,
-                        trackDetails.Track_Number
+                        trackDetails.Track_Number,
+                        trackDetails.ArtistId,
+                        trackDetails.ArtistName
                     );
                     tracks.Add(trackDto);
                 }

--- a/Spotify-Data-Collector/Classes/SpotifyUser.cs
+++ b/Spotify-Data-Collector/Classes/SpotifyUser.cs
@@ -1,10 +1,55 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Identity.Data;
 using SpotifyDataCollector;
+using SpotifyAPI.Web;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Builder;
 
 namespace SpotifyUser{
-    public class User{
+    
+    public class User: IUser{
+        private string _loginURI = "http://localhost:5272/redirect";
+        private ISpotifyService _spotifyService = new Spotify();
 
+        public string LoginURI{
+            get{
+                return _loginURI;
+            }
+        }
+
+
+        public Task InitiateSpotifyLoginAsync(HttpContext context)
+        {
+            var loginRequest = new SpotifyAPI.Web.LoginRequest(
+                new Uri(_loginURI),
+                _spotifyService.GetClientId(),
+                SpotifyAPI.Web.LoginRequest.ResponseType.Code
+            )
+            {
+                Scope = new[] { Scopes.PlaylistReadPrivate, Scopes.PlaylistReadCollaborative, Scopes.UserLibraryRead, Scopes.UserReadRecentlyPlayed, Scopes.UserTopRead }
+            };
+            var uri = loginRequest.ToUri();
+            context.Response.Redirect(uri.ToString());
+            return Task.CompletedTask;
+        }
+
+        public async Task<SpotifyClient> GetSpotifyClientAsync(HttpContext context)
+        {
+            var code = context.Request.Query["code"].ToString();
+            var response = await new OAuthClient().RequestToken(
+                new AuthorizationCodeTokenRequest(
+                    _spotifyService.GetClientId(), // Replace with your Spotify Client ID
+                    _spotifyService.GetClientSecret(), // Replace with your Spotify Client Secret
+                    code,
+                    new Uri(_loginURI)
+                )
+            );
+            var spotify = new SpotifyClient(response.AccessToken);
+            return spotify;
+        }
+        
     }
 }

--- a/Spotify-Data-Collector/Classes/SpotifyUser.cs
+++ b/Spotify-Data-Collector/Classes/SpotifyUser.cs
@@ -13,7 +13,8 @@ using System.Runtime.Serialization;
 namespace SpotifyUser{
     
     public class User: IUser{
-        private string _loginURI = "http://localhost:5272/redirect";
+        private string _loginURI = 
+            Environment.GetEnvironmentVariable("SPOTIFY_REDIRECT_URI");
         private string _SpotifyUserID;
         private ISpotifyService _spotifyService = new Spotify();
         private SpotifyClient _spotifyClient;

--- a/Spotify-Data-Collector/Classes/SpotifyUser.cs
+++ b/Spotify-Data-Collector/Classes/SpotifyUser.cs
@@ -17,7 +17,6 @@ namespace SpotifyUser{
         private string _SpotifyUserID;
         private ISpotifyService _spotifyService = new Spotify();
         private SpotifyClient _spotifyClient;
-        private DateTimeOffset _tokenExpiryTime;
         private string _spotifyToken;
         private string _spotifyAccessCode;
         private string _tokenExpireTime;
@@ -99,8 +98,6 @@ namespace SpotifyUser{
                 )
             );
 
-            _tokenExpiryTime = DateTimeOffset.Now.AddSeconds(response.ExpiresIn - 60);
-
             var config = SpotifyClientConfig.CreateDefault()
                 .WithAuthenticator(new AuthorizationCodeAuthenticator(
                     _spotifyService.GetClientId(), // Replace with your Spotify Client ID
@@ -108,10 +105,10 @@ namespace SpotifyUser{
                     response
                 )
             );
-            this.SpotifyClient = new SpotifyClient(config);
-            this.SpotifyToken = response.RefreshToken;            
-            this.TokenExpireTime = DateTime.Now.AddSeconds(response.ExpiresIn).ToString();
-            return this.SpotifyClient;
+            SpotifyClient = new SpotifyClient(config);
+            SpotifyToken = response.RefreshToken;            
+            TokenExpireTime = DateTime.Now.AddSeconds(response.ExpiresIn).ToString();
+            return SpotifyClient;
         
         }
 
@@ -124,13 +121,20 @@ namespace SpotifyUser{
                     _spotifyToken
                 )
             );
-            _tokenExpiryTime = DateTimeOffset.Now.AddSeconds(response.ExpiresIn - 60);
+            
             SpotifyClient = new SpotifyClient(response.AccessToken);
             SpotifyToken = response.RefreshToken;
             TokenExpireTime = DateTime.Now.AddSeconds(response.ExpiresIn).ToString();
             await Task.CompletedTask;
         }
         
+        /// <summary>
+        /// Retrieves a list of recent tracks from the Spotify API.
+        /// </summary>
+        /// <param name="spotify">The SpotifyClient instance used to make API requests.</param>
+        /// <param name="startTime">Optional. The start time to filter the recent tracks. Defaults to null.</param>
+        /// <param name="endTime">Optional. The end time to filter the recent tracks. Defaults to null.</param>
+        /// <returns>A list of TrackDTO objects representing the recent tracks.</returns>
         public async Task<List<TrackDTO>> GetRecentTracksAsync(SpotifyClient spotify, DateTimeOffset? startTime = null, DateTimeOffset? endTime = null)
         {
             var recentlyPlayedRequest = new PlayerRecentlyPlayedRequest()
@@ -163,8 +167,14 @@ namespace SpotifyUser{
             return tracks;
         }
         
+        /// <summary>
+        /// Check if the token will expire in the next minute
+        /// </summary>
+        /// <returns>
+        /// True if the token will expire in the next minute, false otherwise
+        /// </returns>
         public bool IsTokenExpired()
-        {;
+        {
             return DateTime.Now > DateTime.Parse(TokenExpireTime) - TimeSpan.FromSeconds(60);
         }
         

--- a/Spotify-Data-Collector/Classes/SpotifyUser.cs
+++ b/Spotify-Data-Collector/Classes/SpotifyUser.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using SpotifyDataCollector;
+
+namespace SpotifyUser{
+    public class User{
+
+    }
+}

--- a/Spotify-Data-Collector/Classes/SpotifyUser.cs
+++ b/Spotify-Data-Collector/Classes/SpotifyUser.cs
@@ -7,16 +7,27 @@ using SpotifyDataCollector;
 using SpotifyAPI.Web;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Builder;
+using Spotify_Data_Collector;
 
 namespace SpotifyUser{
     
     public class User: IUser{
         private string _loginURI = "http://localhost:5272/redirect";
+        private string _SpotifyUserID;
         private ISpotifyService _spotifyService = new Spotify();
-
+        
         public string LoginURI{
             get{
                 return _loginURI;
+            }
+        }
+
+        public string SpotifyUserID{
+            get{
+                return _SpotifyUserID;
+            }
+            set{
+                _SpotifyUserID = value;
             }
         }
 
@@ -50,6 +61,37 @@ namespace SpotifyUser{
             var spotify = new SpotifyClient(response.AccessToken);
             return spotify;
         }
+
+        public async Task<List<TrackDTO>> GetRecentTracksAsync(SpotifyClient spotify, DateTimeOffset? startTime = null, DateTimeOffset? endTime = null)
+        {
+            var recentlyPlayedRequest = new PlayerRecentlyPlayedRequest()
+            {
+                Limit = 10 // Replace with the desired number of recent tracks to retrieve
+            };
+             // Convert startTime and endTime to milliseconds since Unix epoch if they are not null
+            if (startTime.HasValue)
+            {
+                recentlyPlayedRequest.After = (long)(startTime.Value - new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero)).TotalMilliseconds;
+            }
+            if (endTime.HasValue)
+            {
+                recentlyPlayedRequest.Before = (long)(endTime.Value - new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero)).TotalMilliseconds;
+            }
+            var recentlyPlayed = await spotify.Player.GetRecentlyPlayed(recentlyPlayedRequest);
+            var tracks = recentlyPlayed.Items.Select(item => new TrackDTO(
+                item.Track.Name,
+                item.Track.Id,
+                item.Track.DurationMs.ToString(),
+                item.Track.Popularity.ToString(),
+                item.Track.ExternalUrls["spotify"],
+                item.Track.Album.Id,
+                item.Track.Album.ReleaseDate,
+                item.Track.DiscNumber.ToString(),
+                item.Track.TrackNumber.ToString()
+            )).ToList();
+            return tracks;
+        }
+        
         
     }
 }

--- a/Spotify-Data-Collector/Data/TrackDTO.cs
+++ b/Spotify-Data-Collector/Data/TrackDTO.cs
@@ -17,7 +17,10 @@ namespace Spotify_Data_Collector{
         public string Disc_Number { get; set; }
         public string Track_Number { get; set; }
 
-        public TrackDTO(string name, string spotifyId, string duration, string popularity, string spotifyUrl, string albumId, string releaseDate, string disc_Number, string track_Number)
+        public string ArtistId { get; set; }
+        public string ArtistName { get; set; }
+
+        public TrackDTO(string name, string spotifyId, string duration, string popularity, string spotifyUrl, string albumId, string releaseDate, string disc_Number, string track_Number, string artistId, string artistName)
         {
             Name = name;
             SpotifyId = spotifyId;
@@ -28,6 +31,9 @@ namespace Spotify_Data_Collector{
             ReleaseDate = releaseDate;
             Disc_Number = disc_Number;
             Track_Number = track_Number;
+            ArtistId = artistId;
+            ArtistName = artistName;
         }
+        
     }
 }

--- a/Spotify-Data-Collector/Program.cs
+++ b/Spotify-Data-Collector/Program.cs
@@ -58,20 +58,12 @@ app.MapGet("/login", (HttpContext context) =>
 );
 app.MapGet("/redirect", async (HttpContext context) =>
 {
-    /*
-    var code = context.Request.Query["code"].ToString();
-    var response = await new OAuthClient().RequestToken(
-      new AuthorizationCodeTokenRequest(
-        spotifyService.GetClientId(), // Replace with your Spotify Client ID
-        spotifyService.GetClientSecret(), // Replace with your Spotify Client Secret
-        code,
-        new Uri("http://localhost:5272/redirect")
-      )
-    );
-    var spotify = new SpotifyClient(response.AccessToken);*/
+    
     var spotify = await user.GetSpotifyClientAsync(context);
     var profile = await spotify.UserProfile.Current();
-    return Results.Ok(profile.DisplayName);
+    user.SpotifyUserID = profile.Id;
+    var tracks = await user.GetRecentTracksAsync(spotify, null, DateTime.Now);
+    return Results.Ok(tracks.ToList());
 }
 );
 

--- a/Spotify-Data-Collector/Spotify-Data-Collector.generated.sln
+++ b/Spotify-Data-Collector/Spotify-Data-Collector.generated.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.002.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Spotify-Data-Collector", "Spotify-Data-Collector.csproj", "{201D7193-3D9B-48D8-8C99-56E7387ED251}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Spotify-Data-Collector", "Spotify-Data-Collector.csproj", "{B8FFB19D-5F14-4C30-9F06-234FCF4FBDA4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -11,10 +11,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{201D7193-3D9B-48D8-8C99-56E7387ED251}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{201D7193-3D9B-48D8-8C99-56E7387ED251}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{201D7193-3D9B-48D8-8C99-56E7387ED251}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{201D7193-3D9B-48D8-8C99-56E7387ED251}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B8FFB19D-5F14-4C30-9F06-234FCF4FBDA4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B8FFB19D-5F14-4C30-9F06-234FCF4FBDA4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B8FFB19D-5F14-4C30-9F06-234FCF4FBDA4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B8FFB19D-5F14-4C30-9F06-234FCF4FBDA4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Spotify-Data-Collector/Spotify-Data-Collector.generated.sln
+++ b/Spotify-Data-Collector/Spotify-Data-Collector.generated.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.002.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Spotify-Data-Collector", "Spotify-Data-Collector.csproj", "{F1B747E5-55CC-4A05-B6C7-24572F64B41E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Spotify-Data-Collector", "Spotify-Data-Collector.csproj", "{201D7193-3D9B-48D8-8C99-56E7387ED251}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -11,10 +11,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{F1B747E5-55CC-4A05-B6C7-24572F64B41E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{F1B747E5-55CC-4A05-B6C7-24572F64B41E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F1B747E5-55CC-4A05-B6C7-24572F64B41E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F1B747E5-55CC-4A05-B6C7-24572F64B41E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{201D7193-3D9B-48D8-8C99-56E7387ED251}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{201D7193-3D9B-48D8-8C99-56E7387ED251}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{201D7193-3D9B-48D8-8C99-56E7387ED251}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{201D7193-3D9B-48D8-8C99-56E7387ED251}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Spotify-Data-Collector/Spotify-Data-Collector.generated.sln
+++ b/Spotify-Data-Collector/Spotify-Data-Collector.generated.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.002.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Spotify-Data-Collector", "Spotify-Data-Collector.csproj", "{A4E9A100-C1D3-493F-8497-DD964251AF34}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Spotify-Data-Collector", "Spotify-Data-Collector.csproj", "{F1B747E5-55CC-4A05-B6C7-24572F64B41E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -11,10 +11,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{A4E9A100-C1D3-493F-8497-DD964251AF34}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A4E9A100-C1D3-493F-8497-DD964251AF34}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A4E9A100-C1D3-493F-8497-DD964251AF34}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A4E9A100-C1D3-493F-8497-DD964251AF34}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F1B747E5-55CC-4A05-B6C7-24572F64B41E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F1B747E5-55CC-4A05-B6C7-24572F64B41E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F1B747E5-55CC-4A05-B6C7-24572F64B41E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F1B747E5-55CC-4A05-B6C7-24572F64B41E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Adds functionality to request an authorization token from Spotify for a user, handle refreshing of the token when expires, and adds a simple /user/recenttracks route that returns the last 10 tracks listened to by the user.

Also creates a User class object to handle managing the spotify user interactions.